### PR TITLE
Enhance amplitude training and risk controls

### DIFF
--- a/attach_market_features.py
+++ b/attach_market_features.py
@@ -6,8 +6,10 @@ Ajoute des features de marché à t0 pour chaque événement (sans fuite).
 Réutilisable comme fonction dans live_pipeline.
 """
 
-import pandas as pd
+import math
+
 import numpy as np
+import pandas as pd
 
 
 def as_utc(s):
@@ -29,6 +31,13 @@ def realized_vol(ret1m, window):
     return ret1m.rolling(window).std()
 
 
+def annualize_vol(vol, window):
+    if window <= 0:
+        return vol
+    scale = math.sqrt(1440 / window)
+    return vol * scale
+
+
 def true_range(df):
     prev_close = df["close"].shift(1)
     tr = pd.concat([
@@ -40,7 +49,7 @@ def true_range(df):
 
 
 def attach_features_to_df(ev: pd.DataFrame, px: pd.DataFrame) -> pd.DataFrame:
-    """Ajoute des features marché (RSI, ATR, vol, SMA…) à un dataframe d'événements."""
+    """Ajoute des features marché et contextuelles à chaque événement."""
     ev = ev.copy()
     ev["event_time"] = as_utc(ev["event_time"])
     px["timestamp"] = as_utc(px["timestamp"])
@@ -51,30 +60,58 @@ def attach_features_to_df(ev: pd.DataFrame, px: pd.DataFrame) -> pd.DataFrame:
     px = px.reindex(full_idx).ffill()
 
     # Retours
-    px["ret1m"] = np.log(px["close"] / px["close"].shift(1))
+    px["ret1m"] = px["close"].pct_change()
+    px["logret1m"] = np.log(px["close"] / px["close"].shift(1))
 
-    # Volatilité réalisée
-    for w in [30, 60, 120]:
-        px[f"vol_{w}m"] = realized_vol(px["ret1m"], w)
-        px[f"ret_{w}m_back"] = np.log(px["close"] / px["close"].shift(w))
+    # Volatilité réalisée multi-horizons (simple et annualisée)
+    for w in [30, 60, 120, 240]:
+        rv = realized_vol(px["logret1m"], w)
+        px[f"realized_vol_{w}m"] = rv
+        px[f"realized_vol_{w}m_annual"] = annualize_vol(rv, w)
 
     # RSI
     px["rsi_14"] = rsi(px["close"], period=14)
 
-    # ATR
+    # ATR + version normalisée par le prix
     tr = true_range(px)
     for w in [30, 60, 120]:
-        px[f"atr_{w}m"] = tr.rolling(w).mean()
+        atr = tr.rolling(w).mean()
+        px[f"atr_{w}m"] = atr
+        px[f"atr_{w}m_pct"] = atr / (px["close"].rolling(1).mean() + 1e-12)
 
-    # Z-score volume
+    # Largeur de bandes de Bollinger (20 périodes)
+    mid = px["close"].rolling(20).mean()
+    std = px["close"].rolling(20).std()
+    px["boll_width_20"] = (2 * std) / (mid + 1e-12)
+
+    # Momentum prix
+    for w in [5, 15, 30, 60]:
+        px[f"momentum_{w}m"] = px["close"].pct_change(w)
+
+    # Volume et liquidité
     px["vol_z_60m"] = (px["volume"] - px["volume"].rolling(60).mean()) / (px["volume"].rolling(60).std() + 1e-12)
+    px["volume_rate_30m"] = px["volume"].rolling(5).sum() / (px["volume"].rolling(30).sum() + 1e-12)
+    px["volume_trend_120m"] = px["volume"].ewm(span=120, adjust=False).mean()
 
     # Moyennes mobiles
     px["sma_10"] = px["close"].rolling(10).mean()
     px["sma_50"] = px["close"].rolling(50).mean()
     px["sma10_sma50_diff"] = (px["sma_10"] - px["sma_50"]) / (px["sma_50"] + 1e-12)
 
-    feat_cols = [c for c in px.columns if c not in ["open", "high", "low", "close", "volume", "ret1m"]]
+    # Signatures temporelles (sin/cos heure, jour semaine)
+    idx = px.index
+    if getattr(idx, "tz", None) is None:
+        idx = idx.tz_localize("UTC")
+    else:
+        idx = idx.tz_convert("UTC")
+    hour_float = idx.hour + idx.minute / 60.0
+    px["intraday_sin"] = np.sin(2 * np.pi * hour_float / 24)
+    px["intraday_cos"] = np.cos(2 * np.pi * hour_float / 24)
+    px["dow_sin"] = np.sin(2 * np.pi * idx.dayofweek / 7)
+    px["dow_cos"] = np.cos(2 * np.pi * idx.dayofweek / 7)
+    px["is_weekend"] = (idx.dayofweek >= 5).astype(float)
+
+    feat_cols = [c for c in px.columns if c not in ["open", "high", "low", "close", "volume", "ret1m", "logret1m"]]
 
     def get_feats_at(t):
         try:
@@ -85,7 +122,36 @@ def attach_features_to_df(ev: pd.DataFrame, px: pd.DataFrame) -> pd.DataFrame:
     feats = pd.DataFrame([get_feats_at(t) for t in ev["event_time"].tolist()]).reset_index(drop=True)
     feats.columns = [f"feat_{c}" for c in feats.columns]
 
-    out = pd.concat([ev.reset_index(drop=True), feats], axis=1)
+    # Features sentiment / flux d'event (agrégation locale)
+    ev = ev.reset_index(drop=True)
+    ev["event_time"] = as_utc(ev["event_time"])
+    ev = ev.sort_values("event_time").reset_index(drop=True)
+
+    if "sentiment_score" in ev.columns:
+        sent = pd.to_numeric(ev["sentiment_score"], errors="coerce").fillna(0.0)
+    elif "sentiment" in ev.columns:
+        sent = pd.to_numeric(ev["sentiment"], errors="coerce").fillna(0.0)
+    else:
+        sent = pd.Series(np.zeros(len(ev)))
+
+    sent_roll = sent.rolling(window=10, min_periods=1).mean().shift(1).fillna(0.0)
+    sent_std = sent.rolling(window=10, min_periods=2).std().shift(1).fillna(0.0)
+
+    ev_idx = ev.set_index("event_time")
+    ones = pd.Series(1.0, index=ev_idx.index)
+    flux_60 = ones.rolling("60min", closed="left").sum().fillna(0.0).values
+    flux_180 = ones.rolling("180min", closed="left").sum().fillna(0.0).values
+
+    context_feats = pd.DataFrame(
+        {
+            "feat_sent_roll_mean_10": sent_roll.values,
+            "feat_sent_roll_std_10": sent_std.values,
+            "feat_news_count_60m": flux_60,
+            "feat_news_count_180m": flux_180,
+        }
+    )
+
+    out = pd.concat([ev.reset_index(drop=True), feats, context_feats], axis=1)
     return out
 
 

--- a/live_trader.py
+++ b/live_trader.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import csv
 import json
-import math
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -29,12 +28,18 @@ REFRESH_SEC = 2
 
 CONF_OPEN = 0.62
 CONF_CLOSE = 0.55
+CONF_BASELINE = 0.50
 MIN_COOLDOWN_SEC = 60
 BASE_POSITION_USD = 1000
 MAX_LEVERAGE = 8
+RISK_CAP_PCT = 0.02  # 2% de l'équité en risque par trade
+MIN_RISK_SCORE = 0.12
+ATR_VERY_LOW = 0.0015
+ATR_LOW = 0.0030
+ATR_HIGH = 0.0065
 SL_FLOOR = 0.003  # 0.3%
-TP_MULTIPLIER = 1.4
-SL_MULTIPLIER = 0.9
+TP_MULTIPLIER = 1.6
+SL_MULTIPLIER = 0.85
 
 BINANCE_PRICE_URL = "https://api.binance.com/api/v3/ticker/price?symbol=BTCUSDT"
 
@@ -43,6 +48,111 @@ LABELS = ["bearish", "neutral", "bullish"]
 
 def now_iso() -> str:
     return datetime.now(timezone.utc).astimezone().isoformat()
+
+
+def safe_float(value) -> Optional[float]:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def compute_risk_fraction(confidence: float, mag_value: float, atr_pct: Optional[float],
+                          thresholds: Optional[Dict[str, Dict[str, float]]]) -> float:
+    edge = max(0.0, confidence - CONF_BASELINE)
+    conf_weight = min(1.0, edge / max(1e-6, 1.0 - CONF_BASELINE))
+
+    amp_weight = 0.4
+    if thresholds and "60" in thresholds:
+        bucket = thresholds["60"]
+        q1 = bucket.get("q1", 0.001)
+        q2 = bucket.get("q2", 0.003)
+        if mag_value >= q2:
+            amp_weight = 1.0
+        elif mag_value >= q1:
+            amp_weight = 0.65
+        else:
+            amp_weight = 0.35
+    else:
+        amp_weight = min(1.0, mag_value / 0.01)
+
+    score = conf_weight * amp_weight
+    if atr_pct is not None:
+        if atr_pct < ATR_VERY_LOW:
+            score *= 1.2
+        elif atr_pct > ATR_HIGH:
+            score *= 0.6
+        elif atr_pct > ATR_LOW:
+            score *= 0.85
+    return max(0.0, min(1.0, score))
+
+
+def select_leverage(mag_value: float, thresholds: Optional[Dict[str, Dict[str, float]]],
+                    atr_pct: Optional[float]) -> int:
+    base = 1
+    if thresholds and "60" in thresholds:
+        bucket = thresholds["60"]
+        q1 = bucket.get("q1", 0.001)
+        q2 = bucket.get("q2", 0.003)
+        if mag_value >= q2:
+            base = 4
+        elif mag_value >= q1:
+            base = 2
+        else:
+            base = 1
+    else:
+        base = 1 + int(min(MAX_LEVERAGE - 1, max(0.0, mag_value * 400)))
+
+    if atr_pct is not None:
+        if atr_pct >= ATR_HIGH:
+            base = max(1, base - 2)
+        elif atr_pct >= ATR_LOW:
+            base = max(1, base - 1)
+        elif atr_pct <= ATR_VERY_LOW:
+            base = min(MAX_LEVERAGE, base + 1)
+    return max(1, min(MAX_LEVERAGE, base))
+
+
+def compute_tp_sl(ret_pred: float, confidence: float, atr_pct: Optional[float], side: str) -> Dict[str, float]:
+    magnitude = abs(ret_pred)
+    atr_component = atr_pct if atr_pct is not None else SL_FLOOR
+    anchor = max(SL_FLOOR, max(magnitude, atr_component))
+    conf_boost = 1.0 + max(0.0, confidence - CONF_BASELINE) * 1.2
+    tp_pct = anchor * TP_MULTIPLIER * conf_boost
+    sl_pct = max(SL_FLOOR, anchor * SL_MULTIPLIER / conf_boost)
+    return {
+        "tp_pct": tp_pct,
+        "sl_pct": sl_pct,
+    }
+
+
+def build_risk_plan(state: Dict, confidence: float, ret_pred: float,
+                    thresholds: Optional[Dict[str, Dict[str, float]]], atr_pct: Optional[float]) -> Optional[Dict]:
+    mag_value = abs(ret_pred)
+    risk_fraction = compute_risk_fraction(confidence, mag_value, atr_pct, thresholds)
+    if risk_fraction < MIN_RISK_SCORE:
+        return None
+
+    leverage = select_leverage(mag_value, thresholds, atr_pct)
+    equity = float(state.get("equity") or state.get("starting_equity") or 10000.0)
+    equity = max(equity, float(state.get("starting_equity", 10000.0)))
+    risk_budget = equity * RISK_CAP_PCT * risk_fraction
+    if risk_budget <= 0:
+        risk_budget = BASE_POSITION_USD * max(risk_fraction, 0.25)
+
+    size_usd = risk_budget * leverage
+    return {
+        "size_usd": float(max(size_usd, BASE_POSITION_USD * 0.5)),
+        "leverage": int(leverage),
+        "risk_fraction": float(risk_fraction),
+        "risk_budget": float(risk_budget),
+        "confidence": float(confidence),
+        "ret_pred": float(ret_pred),
+        "mag_pred": float(mag_value),
+        "atr_pct": None if atr_pct is None else float(atr_pct),
+    }
 
 
 def read_last_price() -> Optional[float]:
@@ -112,26 +222,6 @@ def load_thresholds() -> Optional[Dict[str, Dict[str, float]]]:
         return None
 
 
-def compute_leverage(mag_value: float, thresholds: Optional[Dict[str, Dict[str, float]]]) -> int:
-    if thresholds and "60" in thresholds:
-        q = thresholds["60"]
-        q2 = max(q.get("q2", 0.001), 1e-6)
-        scaled = mag_value / q2
-        leverage = 1 + int(round(min(MAX_LEVERAGE - 1, max(0.0, scaled * 4))))
-        return max(1, min(MAX_LEVERAGE, leverage))
-    return 1
-
-
-def compute_tp_sl(mag_value: float, side: str) -> Dict[str, float]:
-    target = max(SL_FLOOR, mag_value)
-    tp_pct = target * TP_MULTIPLIER
-    sl_pct = max(SL_FLOOR, target * SL_MULTIPLIER)
-    return {
-        "tp_pct": tp_pct,
-        "sl_pct": sl_pct,
-    }
-
-
 def latest_predictions(n: int = 40) -> pd.DataFrame:
     if not PRED_FILE.exists():
         return pd.DataFrame()
@@ -148,8 +238,19 @@ def latest_predictions(n: int = 40) -> pd.DataFrame:
         "prob_neut",
         "prob_bull",
         "confidence",
+        "ret_pred",
+        "ret_30m_pred",
+        "ret_120m_pred",
         "mag_pred",
         "mag_bucket",
+        "mag_30m_pred",
+        "mag_120m_pred",
+        "feat_atr_60m_pct",
+        "feat_atr_30m_pct",
+        "feat_realized_vol_60m",
+        "feat_realized_vol_60m_annual",
+        "feat_vol_z_60m",
+        "feat_volume_rate_30m",
     }
     for col in required:
         if col not in df.columns:
@@ -176,16 +277,18 @@ def close_position(state: Dict, price: float, reason: str = "CLOSE") -> None:
             "pnl": round(pnl, 2),
             "title": pos.get("title", ""),
             "leverage": pos.get("leverage", 1),
+            "risk_fraction": round(float(pos.get("risk_fraction", 0.0)), 4),
         }
     )
     state["position"] = None
 
 
-def open_position(state: Dict, side: str, price: float, title: str, leverage: int, mag_value: float) -> None:
-    tp_sl = compute_tp_sl(mag_value, side)
+def open_position(state: Dict, side: str, price: float, title: str, plan: Dict) -> None:
+    tp_sl = compute_tp_sl(plan.get("ret_pred", 0.0), plan.get("confidence", 0.0), plan.get("atr_pct"), side)
     tp = price * (1 + tp_sl["tp_pct"]) if side == "long" else price * (1 - tp_sl["tp_pct"])
     sl = price * (1 - tp_sl["sl_pct"]) if side == "long" else price * (1 + tp_sl["sl_pct"])
-    size = BASE_POSITION_USD * leverage
+    size = plan.get("size_usd", BASE_POSITION_USD)
+    leverage = plan.get("leverage", 1)
     state["position"] = {
         "side": side,
         "entry": float(price),
@@ -195,7 +298,12 @@ def open_position(state: Dict, side: str, price: float, title: str, leverage: in
         "sl": float(sl),
         "title": title[:160],
         "leverage": leverage,
-        "mag_pred": mag_value,
+        "mag_pred": plan.get("mag_pred", 0.0),
+        "ret_pred": plan.get("ret_pred", 0.0),
+        "risk_fraction": plan.get("risk_fraction", 0.0),
+        "risk_budget": plan.get("risk_budget", 0.0),
+        "atr_pct": plan.get("atr_pct"),
+        "confidence": plan.get("confidence", 0.0),
     }
     state["trades"].append(
         {
@@ -206,6 +314,7 @@ def open_position(state: Dict, side: str, price: float, title: str, leverage: in
             "pnl": 0.0,
             "title": title[:160],
             "leverage": leverage,
+            "risk_fraction": round(plan.get("risk_fraction", 0.0), 4),
         }
     )
 
@@ -256,19 +365,24 @@ def main():
                 state["last_pred_id"] = news_id
                 pred = str(last_row.get("prediction", "neutral")).lower()
                 confidence = float(last_row.get("confidence", 0.0) or 0.0)
-                mag_value = float(last_row.get("mag_pred", 0.0) or 0.0)
+                ret_pred = safe_float(last_row.get("ret_pred"))
+                if ret_pred is None:
+                    mag_raw = float(last_row.get("mag_pred", 0.0) or 0.0)
+                    direction = -1.0 if pred == "bearish" else (1.0 if pred == "bullish" else 0.0)
+                    ret_pred = mag_raw * direction
+                mag_value = abs(ret_pred)
+                atr_pct = safe_float(last_row.get("feat_atr_60m_pct"))
                 title = str(last_row.get("title", ""))
 
                 now_s = time.time()
                 if now_s - last_action_ts >= MIN_COOLDOWN_SEC:
+                    plan = build_risk_plan(state, confidence, ret_pred, thresholds, atr_pct)
                     if state.get("position") is None:
-                        if pred == "bullish" and confidence >= CONF_OPEN and price:
-                            lev = compute_leverage(mag_value, thresholds)
-                            open_position(state, "long", price, title, lev, mag_value)
+                        if pred == "bullish" and confidence >= CONF_OPEN and price and plan:
+                            open_position(state, "long", price, title, plan)
                             last_action_ts = now_s
-                        elif pred == "bearish" and confidence >= CONF_OPEN and price:
-                            lev = compute_leverage(mag_value, thresholds)
-                            open_position(state, "short", price, title, lev, mag_value)
+                        elif pred == "bearish" and confidence >= CONF_OPEN and price and plan:
+                            open_position(state, "short", price, title, plan)
                             last_action_ts = now_s
                     else:
                         pos = state["position"]
@@ -278,14 +392,14 @@ def main():
                             last_action_ts = now_s
                         elif side == "long" and pred == "bearish" and confidence >= CONF_OPEN and price:
                             close_position(state, price, reason="CLOSE flip")
-                            lev = compute_leverage(mag_value, thresholds)
-                            open_position(state, "short", price, title, lev, mag_value)
                             last_action_ts = now_s
+                            if plan:
+                                open_position(state, "short", price, title, plan)
                         elif side == "short" and pred == "bullish" and confidence >= CONF_OPEN and price:
                             close_position(state, price, reason="CLOSE flip")
-                            lev = compute_leverage(mag_value, thresholds)
-                            open_position(state, "long", price, title, lev, mag_value)
                             last_action_ts = now_s
+                            if plan:
+                                open_position(state, "long", price, title, plan)
 
         mark_to_market(state, price)
         save_state(state)

--- a/make_event_labels_v2.py
+++ b/make_event_labels_v2.py
@@ -1,12 +1,27 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-make_event_labels.py
-Ajoute les labels directionnels et magnitude aux news (GDELT ou format interne).
+"""make_event_labels_v2
+========================
+
+Génère des cibles multi-horizons à partir d'un historique OHLCV 1 minute.
+
+Pour chaque événement, on calcule :
+
+* le label directionnel (bearish / neutral / bullish) basé sur un seuil dynamique
+  proportionnel à l'ATR courant,
+* le rendement signé ``ret_{h}m`` (pct_change) pour chaque horizon,
+* la magnitude absolue ``mag_{h}m`` (``abs(ret_{h}m)``).
+
+Ces informations permettent ensuite d'entraîner un modèle multi-tâches qui
+prévoit simultanément la direction et l'amplitude du mouvement.
 """
 
-import argparse, pandas as pd, numpy as np
-from datetime import datetime, timedelta, timezone
+import argparse
+from datetime import timedelta
+from typing import Dict, Iterable, Optional
+
+import numpy as np
+import pandas as pd
 
 # =====================
 # Helpers
@@ -14,30 +29,59 @@ from datetime import datetime, timedelta, timezone
 def as_utc_series(s: pd.Series):
     return pd.to_datetime(s, utc=True, errors="coerce")
 
-def compute_labels(ev_time, prices, horizons=[30,60,120]):
-    """
-    Calcule labels directionnels et magnitude sur plusieurs horizons.
-    """
-    out = {}
-    for h in horizons:
-        dt_future = ev_time + timedelta(minutes=h)
-        # trouver la bougie la plus proche
-        sub = prices.loc[prices["ts"] >= dt_future]
-        if sub.empty:
+ATR_COL = "atr_30m_pct"
+RET_THRESH_BASE = 0.0005  # 0.05%
+RET_THRESH_ATR_MULT = 0.35  # 35% de l'ATR pour déclencher bullish/bearish
+
+
+def compute_direction(ret: float, atr_pct: Optional[float]) -> str:
+    """Convertit un rendement en label directionnel."""
+
+    thresh = RET_THRESH_BASE
+    if atr_pct is not None and not np.isnan(atr_pct):
+        thresh = max(thresh, float(atr_pct) * RET_THRESH_ATR_MULT)
+
+    if ret > thresh:
+        return "bullish"
+    if ret < -thresh:
+        return "bearish"
+    return "neutral"
+
+
+def compute_labels(ev_time: pd.Timestamp, prices: pd.DataFrame, horizons: Iterable[int]) -> Dict[str, float | str]:
+    """Calcule labels directionnels, rendements et magnitudes pour un événement."""
+
+    out: Dict[str, float | str] = {}
+    if ev_time.tzinfo is None:
+        ev_time = ev_time.tz_localize("UTC")
+
+    try:
+        base_row = prices.loc[:ev_time].iloc[-1]
+    except IndexError:
+        for h in horizons:
             out[f"label_{h}m"] = np.nan
+            out[f"ret_{h}m"] = np.nan
+            out[f"mag_{h}m"] = np.nan
+        return out
+
+    p0 = float(base_row["close"])
+    atr_pct = float(base_row.get(ATR_COL, np.nan))
+
+    for h in horizons:
+        dt_future = ev_time + timedelta(minutes=int(h))
+        try:
+            p1 = float(prices.loc[:dt_future].iloc[-1]["close"])
+        except IndexError:
+            out[f"label_{h}m"] = np.nan
+            out[f"ret_{h}m"] = np.nan
             out[f"mag_{h}m"] = np.nan
             continue
-        p0 = float(prices.loc[prices["ts"] >= ev_time].iloc[0]["close"])
-        p1 = float(sub.iloc[0]["close"])
-        ret = (p1 - p0) / p0
-        if ret > 0.001:
-            lab = "bullish"
-        elif ret < -0.001:
-            lab = "bearish"
-        else:
-            lab = "neutral"
-        out[f"label_{h}m"] = lab
+
+        ret = (p1 - p0) / max(p0, 1e-9)
+        out[f"label_{h}m"] = compute_direction(ret, atr_pct)
+        out[f"ret_{h}m"] = ret
         out[f"mag_{h}m"] = abs(ret)
+
     return out
 
 # =====================
@@ -68,17 +112,39 @@ def main():
     prices = pd.read_csv(args.ohlcv)
     if "open_time" in prices.columns:
         prices["ts"] = pd.to_datetime(prices["open_time"], unit="ms", utc=True)
-        prices["close"] = prices["close"].astype(float)
     elif "ts" in prices.columns:
         prices["ts"] = pd.to_datetime(prices["ts"], utc=True)
     else:
         raise ValueError("OHLCV doit contenir 'open_time' ou 'ts'")
 
+    prices = prices.rename(columns={c: c.lower() for c in prices.columns})
+    if "close" not in prices.columns:
+        raise ValueError("OHLCV doit contenir une colonne close")
+
+    prices = prices.drop_duplicates(subset=["ts"]).set_index("ts").sort_index()
+
+    # Calcul ATR & volatilité réalisée pour définir des seuils dynamiques
+    high = prices.get("high", prices["close"])
+    low = prices.get("low", prices["close"])
+    close = prices["close"].astype(float)
+    prev_close = close.shift(1)
+    tr = pd.concat([
+        (high - low).abs(),
+        (high - prev_close).abs(),
+        (low - prev_close).abs(),
+    ], axis=1).max(axis=1)
+    atr_30 = tr.rolling(30).mean()
+    prices[ATR_COL] = (atr_30 / close).fillna(method="ffill")
+
+    # Remplissage forward pour éviter les trous dans l'index temporel
+    full_idx = pd.date_range(prices.index.min(), prices.index.max(), freq="1min", tz="UTC")
+    prices = prices.reindex(full_idx).ffill()
+
     # Calcul des labels
     print("[i] Calcul des labels...")
     labels = []
     for _, row in ev.iterrows():
-        labs = compute_labels(row["event_time"], prices)
+        labs = compute_labels(row["event_time"], prices, horizons=[30, 60, 120])
         labels.append(labs)
     lab_df = pd.DataFrame(labels)
 


### PR DESCRIPTION
## Summary
- enrich event labelling to compute continuous signed returns with ATR-aware thresholds
- expand market feature engineering with realized volatility, intraday context, and sentiment aggregates
- retrain the multimodal head on signed returns while exporting absolute targets for live inference
- extend bridge inference outputs with signed return predictions and key market features
- introduce dynamic risk sizing, leverage selection, and volatility-aware stops in the live trader

## Testing
- python3 -m py_compile make_event_labels_v2.py attach_market_features.py train_model_v7_1_multi.py live_trader.py bridge_inference.py

------
https://chatgpt.com/codex/tasks/task_e_68d06dae5f688328933a96bec85fb43b