### PR TITLE
Add model directory fallback for live stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the tooling used to collect crypto news, transform them
 
 1. **News ingestion**: `node rss_to_csv.js` writes deduplicated items (Paris time) into `live_raw.csv`.
 2. **Price pipe writer**: `python live/price_pipe_writer.py` keeps `price_pipe.csv` fresh with Binance BTCUSDT quotes (auto-launched by `run_live_stack.py`).
-3. **Inference bridge**: `python bridge_inference.py` watches `live_raw.csv`, builds market features, runs the multimodal model, and appends rows to `live_predictions.csv`.
+3. **Inference bridge**: `python bridge_inference.py` watches `live_raw.csv`, fetches full article bodies, rebuilds the same market/context features used during training, runs the multimodal model, and appends rows (with article/feature diagnostics) to `live_predictions.csv`.
 4. **Paper trader**: `python live_trader.py` transforms predictions into positions, updates `bot_state.json`, and tracks equity.
 5. **Dashboard**: `streamlit run app.py` shows the BTC chart, predictions, trades, and the equity curve.
 
@@ -31,6 +31,8 @@ node rss_to_csv.js
 ```
 
 Optional: run `python live/price_pipe_writer.py` standalone if you need to feed `price_pipe.csv` manually (two columns: `timestamp,price`). `run_live_stack.py` launches it for you, and `live_trader.py` still falls back to Binance public prices if the file is absent.
+
+> **Model switcher** — Set `MODEL_DIR=/path/to/models/bert_v7_1_plus` (or your preferred export) before starting the stack to point both the bridge, trader, and dashboard to the right checkpoint. If unset, the stack now auto-detects `models/bert_v7_1_plus/` and falls back to `models/bert_v7_1_multi/` when the newer export is absent.
 
 ## Repository structure
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ All timestamps exposed to users are aligned on Europe/Paris.
 
 Historic data preparation and training scripts remain under the root directory. The main entry point is `train_model_v7_1_multi.py`, which expects the dataset produced by `prepare_dataset_full.py` and the helpers in `attach_market_features.py`.
 
+> **Export tip** — The trainer now writes to `models/bert_v7_1_plus/` by default so the live stack picks up fresh checkpoints automatically. Override the target with `OUTPUT_DIR=/path/to/export python train_model_v7_1_multi.py` if you need to keep multiple runs side by side.
+
 ## Quick start (live stack)
 
 ```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Optional: run `python live/price_pipe_writer.py` standalone if you need to feed 
 - `bridge_inference.py`: unified inference loop (direction + magnitude).
 - `live_trader.py`: paper trading engine with dynamic sizing.
 - `app.py`: Streamlit dashboard.
+- `live/state_utils.py`: shared helpers to load/save the bot state and normalise last-signal payloads.
 - `legacy/`: previous live scripts kept for reference.
 - `models/`: trained artifacts.
 - `data/`, `strategies/`, `notebooks/`: historical data and experiments.

--- a/app.py
+++ b/app.py
@@ -18,14 +18,19 @@ import streamlit as st
 from pytz import timezone as pytz_timezone
 from streamlit_autorefresh import st_autorefresh
 
+from live.model_paths import resolve_model_dir
+
 warnings.filterwarnings("ignore", message=".*Styler.applymap.*", category=FutureWarning)
 
 TZ_PARIS = pytz_timezone("Europe/Paris")
 APP_ROOT = Path(__file__).resolve().parent
-
 PREDICTIONS_CSV = APP_ROOT / "live_predictions.csv"
 STATE_FILE = APP_ROOT / "bot_state.json"
-MODEL_DIR = APP_ROOT / "models/bert_v7_1_multi"
+MODEL_DIR = resolve_model_dir(
+    base_dir=APP_ROOT,
+    env_var="MODEL_DIR",
+    candidates=("models/bert_v7_1_plus", "models/bert_v7_1_multi", "models/bert_v7_multi"),
+)
 LIVE_RAW_FILE = APP_ROOT / "live_raw.csv"
 
 BINANCE_PRICE_URL = "https://api.binance.com/api/v3/ticker/price?symbol=BTCUSDT"
@@ -42,6 +47,7 @@ DEFAULT_STATE = {
     "trades": [],
     "equity_curve": [],
     "last_pred_id": None,
+    "last_signal": None,
 }
 
 
@@ -214,16 +220,38 @@ def format_prediction_table(df: pd.DataFrame) -> pd.DataFrame:
         view["heure_paris"] = view["datetime_paris"].dt.strftime("%d/%m %H:%M:%S")
     else:
         view["heure_paris"] = ""
+
+    for required in ["confidence", "ret_pred", "mag_pred", "article_found", "article_chars", "article_status", "text_source"]:
+        if required not in view.columns:
+            if required in {"article_status", "text_source"}:
+                view[required] = ""
+            else:
+                view[required] = np.nan
+
+    view["confidence"] = pd.to_numeric(view["confidence"], errors="coerce")
+    view["confidence"] = view["confidence"].map(lambda x: f"{x:.2f}" if pd.notna(x) else "")
+    view["ret_pred_pct"] = pd.to_numeric(view["ret_pred"], errors="coerce").mul(100.0)
+    view["ret_pred_pct"] = view["ret_pred_pct"].map(lambda x: f"{x:+.2f}%" if pd.notna(x) else "")
+    view["mag_pred_pct"] = pd.to_numeric(view["mag_pred"], errors="coerce").abs().mul(100.0)
+    view["mag_pred_pct"] = view["mag_pred_pct"].map(lambda x: f"{x:.2f}%" if pd.notna(x) else "")
+    view["article_found"] = view["article_found"].map(lambda x: "✅" if bool(x) else "❌")
+    view["article_chars"] = pd.to_numeric(view["article_chars"], errors="coerce").fillna(0).astype(int)
+
     cols = [
         "heure_paris",
         "prediction",
+        "confidence",
+        "ret_pred_pct",
         "prob_bull",
         "prob_neut",
         "prob_bear",
-        "confidence",
-        "mag_pred",
+        "mag_pred_pct",
         "mag_bucket",
         "features_status",
+        "article_status",
+        "article_found",
+        "article_chars",
+        "text_source",
         "title",
     ]
     for c in cols:
@@ -248,7 +276,8 @@ rss_ok, rss_detail = check_rss_status()
 model_ok, model_detail = check_model_status(preds_df)
 trader_ok, trader_detail = check_trader_status(state)
 render_status_badge(status_cols[0], "Flux RSS", rss_ok, rss_detail)
-render_status_badge(status_cols[1], "Modèle v7.1", model_ok, model_detail)
+model_label = f"Modèle {MODEL_DIR.name}"
+render_status_badge(status_cols[1], model_label, model_ok, model_detail)
 render_status_badge(status_cols[2], "Trader fictif", trader_ok, trader_detail)
 
 with st.sidebar:
@@ -329,6 +358,46 @@ with col_right:
         kpi_block("Volume 24h", f"{ticker['volume']:.2f}")
     else:
         st.error(f"Unable to fetch ticker: {ticker.get('error') if isinstance(ticker, dict) else 'unknown error'}")
+
+    st.subheader("Dernier signal")
+    last_signal = state.get("last_signal") if isinstance(state, dict) else None
+    if last_signal:
+        pred = str(last_signal.get("prediction", "")).upper()
+        conf_raw = last_signal.get("confidence")
+        try:
+            conf = float(conf_raw) if conf_raw is not None else None
+        except (TypeError, ValueError):
+            conf = None
+        ret_raw = last_signal.get("ret_pred")
+        try:
+            ret_pred = float(ret_raw) if ret_raw is not None else None
+        except (TypeError, ValueError):
+            ret_pred = None
+        mag_pred = abs(ret_pred) if ret_pred is not None else None
+        lev_raw = last_signal.get("planned_leverage")
+        leverage = int(lev_raw) if isinstance(lev_raw, (int, float)) else None
+        risk_raw = last_signal.get("risk_fraction")
+        risk_fraction = float(risk_raw) if isinstance(risk_raw, (int, float)) else None
+        article_status = last_signal.get("article_status", "")
+        article_found = last_signal.get("article_found")
+        text_source = last_signal.get("text_source", "")
+        features_status = last_signal.get("features_status", "")
+        icon = "🟢" if pred == "BULLISH" else ("🔴" if pred == "BEARISH" else "⚪")
+        lines = [
+            f"{icon} **{pred or '—'}** — confiance {conf:.2f}" if conf is not None else f"{icon} **{pred or '—'}**",
+            f"Retour 60m: {ret_pred * 100:+.2f}% (|{mag_pred * 100:.2f}%|)" if ret_pred is not None else "Retour 60m: n/a",
+            f"Levier planifié: x{int(leverage)}" if leverage else "Levier planifié: n/a",
+            f"Risque engagé: {risk_fraction * 100:.2f}%" if isinstance(risk_fraction, (float, int)) else "Risque engagé: n/a",
+            f"Article: {'✅' if article_found else '⚠️'} {article_status or 'inconnu'} ({text_source or 'n/a'})",
+            f"Features: {features_status or 'n/a'}",
+        ]
+        st.markdown("\n".join(f"- {line}" for line in lines if line))
+        if last_signal.get("title"):
+            st.caption(last_signal.get("title"))
+        if last_signal.get("url"):
+            st.markdown(f"[Voir l'article]({last_signal['url']})")
+    else:
+        st.info("En attente d'un signal du modèle.")
 
     st.subheader("Live predictions")
     if not preds_df.empty:

--- a/bridge_inference.py
+++ b/bridge_inference.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 import csv
 import json
 import time
-from pathlib import Path
 from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
 from typing import Dict, List, Optional
 
 import numpy as np
@@ -23,13 +24,21 @@ import torch
 from torch import nn
 from transformers import AutoTokenizer, AutoModel
 
-from live.feature_builder import LiveFeatureBuilder, FeatureSource
+from fetch_article_bodies import fetch_article_body
+from live.feature_builder import FeatureSource, LiveFeatureBuilder
+from live.model_paths import resolve_model_dir
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
-MODEL_DIR = Path("./models/bert_v7_1_multi")
+SCRIPT_ROOT = Path(__file__).resolve().parent
+MODEL_DIR = resolve_model_dir(
+    base_dir=SCRIPT_ROOT,
+    env_var="MODEL_DIR",
+    candidates=("models/bert_v7_1_plus", "models/bert_v7_1_multi", "models/bert_v7_multi"),
+)
 INPUT_CSV = Path("live_raw.csv")
 OUTPUT_CSV = Path("live_predictions.csv")
 PROCESSED_FILE = Path("live_processed_ids.json")
+ARTICLE_CACHE_FILE = Path("live_article_cache.json")
 
 LABELS = ["bearish", "neutral", "bullish"]
 TARGET_HORIZON = "60"  # use 60m head as primary signal
@@ -53,6 +62,73 @@ EXPORTED_FEATURE_KEYS = [
     "feat_vol_z_60m",
     "feat_volume_rate_30m",
 ]
+
+MAX_ARTICLE_CACHE = 400
+
+
+def load_article_cache() -> Dict[str, Dict[str, str]]:
+    if not ARTICLE_CACHE_FILE.exists():
+        return {}
+    try:
+        data = json.loads(ARTICLE_CACHE_FILE.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return data
+    except Exception as exc:
+        print(f"[WARN] unable to load article cache: {exc}")
+    return {}
+
+
+def save_article_cache(cache: Dict[str, Dict[str, str]]) -> None:
+    items = sorted(
+        cache.items(),
+        key=lambda kv: kv[1].get("fetched_at", ""),
+        reverse=True,
+    )[:MAX_ARTICLE_CACHE]
+    trimmed = {k: v for k, v in items}
+    tmp = ARTICLE_CACHE_FILE.with_suffix(".tmp")
+    tmp.write_text(json.dumps(trimmed, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(ARTICLE_CACHE_FILE)
+
+
+def fetch_article_with_cache(url: str, cache: Dict[str, Dict[str, str]]) -> tuple[str, str]:
+    if not url:
+        return "", "no_url"
+    entry = cache.get(url)
+    if entry:
+        body = entry.get("body", "")
+        status = entry.get("status", "cached" if body else "empty")
+        return body, status
+    body = fetch_article_body(url)
+    status = "fetched" if body else "empty"
+    cache[url] = {
+        "body": body,
+        "status": status,
+        "fetched_at": datetime.utcnow().isoformat(),
+    }
+    try:
+        save_article_cache(cache)
+    except Exception as exc:
+        print(f"[WARN] unable to persist article cache: {exc}")
+    return body, status
+
+
+def build_text_payload(title: str, summary: str, body: str) -> tuple[str, str, str, str]:
+    title_clean = (title or "").strip()
+    summary_clean = (summary or "").strip()
+    body_clean = (body or "").strip()
+
+    titles_joined = title_clean
+    body_concat_parts = [part for part in [summary_clean, body_clean] if part]
+    body_concat = "\n\n".join(body_concat_parts) if body_concat_parts else title_clean
+    text_parts = [part for part in [titles_joined, body_concat] if part]
+    text_for_model = "\n\n".join(text_parts)
+    if body_clean:
+        source = "article"
+    elif summary_clean:
+        source = "summary"
+    else:
+        source = "title"
+    return text_for_model or title_clean, titles_joined, body_concat, source
 
 
 
@@ -141,7 +217,18 @@ def load_live_raw() -> pd.DataFrame:
 class MultiModalHead(nn.Module):
     def __init__(self, model_name: str, feat_dim: int, hidden_drop: float = 0.2):
         super().__init__()
-        self.backbone = AutoModel.from_pretrained(model_name, use_safetensors=True)
+        load_kwargs = {"use_safetensors": True, "low_cpu_mem_usage": True}
+        if DEVICE == "cuda":
+            load_kwargs["torch_dtype"] = torch.float16
+
+        try:
+            self.backbone = AutoModel.from_pretrained(model_name, **load_kwargs)
+        except OSError as err:
+            if "paging file" in str(err).lower() or "1455" in str(err):
+                load_kwargs.pop("use_safetensors", None)
+                self.backbone = AutoModel.from_pretrained(model_name, **load_kwargs)
+            else:
+                raise
         hidden = self.backbone.config.hidden_size
         self.feat_mlp = nn.Sequential(
             nn.Linear(feat_dim, hidden),
@@ -165,7 +252,11 @@ class MultiModalHead(nn.Module):
     def forward(self, input_ids, attention_mask, feats):
         out = self.backbone(input_ids=input_ids, attention_mask=attention_mask)
         cls = out.last_hidden_state[:, 0]
+        if feats.dtype != cls.dtype:
+            feats = feats.to(cls.dtype)
         f = self.feat_mlp(feats)
+        if f.dtype != cls.dtype:
+            f = f.to(cls.dtype)
         z = self.fuse(torch.cat([cls, f], dim=-1))
         o_dir30 = self.dir30(z)
         o_dir60 = self.dir60(z)
@@ -268,6 +359,13 @@ def ensure_output_header():
         "summary",
         "url",
         "source",
+        "titles_joined",
+        "body_concat",
+        "text_source",
+        "text_chars",
+        "article_status",
+        "article_found",
+        "article_chars",
         "processed_at",
     ]
     header.extend(EXPORTED_FEATURE_KEYS)
@@ -298,14 +396,12 @@ def tail_news(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def run_loop():
-    if not MODEL_DIR.exists():
-        raise FileNotFoundError(f"Model directory not found: {MODEL_DIR}")
-
     assets = load_model_assets(MODEL_DIR)
-    feature_builder = LiveFeatureBuilder(FeatureSource())
+    feature_builder = LiveFeatureBuilder(FeatureSource(), feat_stats=assets.feat_norm)
     processed_ids = load_processed_ids()
     processed_set = set(processed_ids)
     ensure_output_header()
+    article_cache = load_article_cache()
 
     print("[INFO] Bridge inference v2 started. Watching", INPUT_CSV)
 
@@ -334,7 +430,24 @@ def run_loop():
                 summary = str(row.get("summary", ""))
                 url = str(row.get("url", ""))
                 source = str(row.get("source", ""))
-                body_text = " ".join(part for part in [title, summary] if part)
+
+                article_body, article_status = fetch_article_with_cache(url, article_cache)
+                text_for_model, titles_joined, body_concat, text_source = build_text_payload(
+                    title,
+                    summary,
+                    article_body,
+                )
+                article_chars = len(article_body.strip()) if article_body else 0
+                article_found = bool(article_body and article_chars >= 200)
+                if article_found:
+                    article_status = f"{article_status}_full"
+                elif article_body:
+                    article_status = f"{article_status}_short"
+                elif summary:
+                    article_status = f"{article_status}_summary"
+                else:
+                    article_status = f"{article_status}_title"
+                text_chars = len(text_for_model)
 
                 dt_paris = pd.to_datetime(row.get("datetime_paris"), utc=True, errors="coerce")
                 dt_utc = pd.to_datetime(row.get("datetime_utc"), utc=True, errors="coerce")
@@ -343,8 +456,18 @@ def run_loop():
                 event_time = dt_utc.to_pydatetime()
 
                 features_status = "live"
+                sentiment_val = 0.0
+                for sent_key in ("sentiment_score", "sentiment"):
+                    raw_sent = row.get(sent_key)
+                    if raw_sent is None or raw_sent == "":
+                        continue
+                    try:
+                        sentiment_val = float(raw_sent)
+                        break
+                    except (TypeError, ValueError):
+                        continue
                 try:
-                    feats = feature_builder.build(event_time)
+                    feats = feature_builder.build(event_time, sentiment=sentiment_val)
                 except Exception as exc:
                     print(f"[WARN] feature builder failed for {news_id}: {exc}; fallback to means")
                     feats = fallback_features(assets.feat_norm)
@@ -353,7 +476,7 @@ def run_loop():
                 Xf = normalize_features(assets.feat_norm, feats, assets.feat_cols)
 
                 enc = assets.tokenizer(
-                    body_text,
+                    text_for_model,
                     truncation=True,
                     padding="max_length",
                     max_length=256,
@@ -378,9 +501,6 @@ def run_loop():
                 bucket = magnitude_bucket(assets.thresholds, ret_60)
 
                 feature_exports = {key: feats.get(key) for key in EXPORTED_FEATURE_KEYS}
-
-                mag_val = float(g60.cpu().numpy().reshape(-1)[0])
-                bucket = magnitude_bucket(assets.thresholds, mag_val)
 
 
                 processed_ids.append(news_id)
@@ -411,6 +531,13 @@ def run_loop():
                     "summary": summary,
                     "url": url,
                     "source": source,
+                    "titles_joined": titles_joined,
+                    "body_concat": body_concat,
+                    "text_source": text_source,
+                    "text_chars": int(text_chars),
+                    "article_status": article_status,
+                    "article_found": bool(article_found),
+                    "article_chars": int(article_chars),
                     "processed_at": pd.Timestamp.utcnow().isoformat(),
                 }
                 out_row.update({k: (None if v is None else float(v)) for k, v in feature_exports.items()})

--- a/live/__init__.py
+++ b/live/__init__.py
@@ -2,3 +2,11 @@
 
 from .feature_builder import FeatureSource, LiveFeatureBuilder  # noqa: F401
 from .model_paths import resolve_model_dir  # noqa: F401
+from .state_utils import (  # noqa: F401
+    build_last_signal,
+    default_state,
+    ensure_state_defaults,
+    load_state_file,
+    save_state_file,
+    update_last_signal_file,
+)

--- a/live/__init__.py
+++ b/live/__init__.py
@@ -1,0 +1,4 @@
+"""Live inference helpers for the sentiment trading bot."""
+
+from .feature_builder import FeatureSource, LiveFeatureBuilder  # noqa: F401
+from .model_paths import resolve_model_dir  # noqa: F401

--- a/live/feature_builder.py
+++ b/live/feature_builder.py
@@ -1,0 +1,227 @@
+"""Utilities for building live market features consistent with the training pipeline."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Deque, Dict, Optional
+
+import numpy as np
+import pandas as pd
+import requests
+
+BINANCE_KLINES_URL = "https://api.binance.com/api/v3/klines"
+
+
+def _as_utc(ts: datetime) -> datetime:
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(timezone.utc)
+
+
+def _annualize_vol(vol: pd.Series, window: int) -> pd.Series:
+    if window <= 0:
+        return vol
+    scale = np.sqrt(1440.0 / window)
+    return vol * scale
+
+
+def _true_range(df: pd.DataFrame) -> pd.Series:
+    prev_close = df["close"].shift(1)
+    tr = pd.concat(
+        [
+            (df["high"] - df["low"]).abs(),
+            (df["high"] - prev_close).abs(),
+            (df["low"] - prev_close).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+    return tr
+
+
+def _rsi(series: pd.Series, period: int = 14) -> pd.Series:
+    delta = series.diff()
+    gain = delta.clip(lower=0).ewm(alpha=1 / period, adjust=False).mean()
+    loss = (-delta.clip(upper=0)).ewm(alpha=1 / period, adjust=False).mean()
+    rs = gain / (loss + 1e-12)
+    return 100 - (100 / (1 + rs))
+
+
+@dataclass
+class FeatureSource:
+    """Fetches 1m OHLCV candles from Binance and keeps a rolling cache."""
+
+    symbol: str = "BTCUSDT"
+    interval: str = "1m"
+    lookback_minutes: int = 360
+    session: Optional[requests.Session] = None
+
+    def __post_init__(self) -> None:
+        self._session = self.session or requests.Session()
+        self._cache: pd.DataFrame = pd.DataFrame()
+        self._cache_updated: Optional[datetime] = None
+
+    def _fetch_klines(self, end_time: Optional[datetime]) -> pd.DataFrame:
+        params = {
+            "symbol": self.symbol,
+            "interval": self.interval,
+            "limit": min(self.lookback_minutes + 5, 1000),
+        }
+        if end_time is not None:
+            params["endTime"] = int(_as_utc(end_time).timestamp() * 1000)
+        resp = self._session.get(BINANCE_KLINES_URL, params=params, timeout=6)
+        resp.raise_for_status()
+        data = resp.json()
+        rows = []
+        for item in data:
+            ts = datetime.fromtimestamp(item[0] / 1000, tz=timezone.utc)
+            rows.append(
+                {
+                    "timestamp": ts,
+                    "open": float(item[1]),
+                    "high": float(item[2]),
+                    "low": float(item[3]),
+                    "close": float(item[4]),
+                    "volume": float(item[5]),
+                }
+            )
+        df = pd.DataFrame(rows).set_index("timestamp").sort_index()
+        return df
+
+    def get_price_window(self, event_time: datetime) -> pd.DataFrame:
+        event_time_utc = _as_utc(event_time)
+        need_start = event_time_utc - timedelta(minutes=self.lookback_minutes)
+
+        refresh_needed = (
+            self._cache.empty
+            or self._cache.index.max() < event_time_utc
+            or self._cache.index.min() > need_start
+        )
+        if refresh_needed:
+            fetched = self._fetch_klines(event_time_utc)
+            if fetched.empty:
+                raise RuntimeError("Binance klines response empty")
+            self._cache = fetched
+            self._cache_updated = datetime.now(timezone.utc)
+
+        window = self._cache.loc[(self._cache.index >= need_start) & (self._cache.index <= event_time_utc)]
+        if window.empty:
+            raise RuntimeError("Insufficient OHLCV history for feature computation")
+        return window.copy()
+
+
+class LiveFeatureBuilder:
+    """Recomputes the training-time market & context features for a live event."""
+
+    def __init__(
+        self,
+        source: FeatureSource,
+        feat_stats: Optional[Dict[str, Dict[str, float]]] = None,
+        history_size: int = 512,
+    ) -> None:
+        self.source = source
+        self.feat_stats = feat_stats or {}
+        self.history: Deque[tuple[datetime, float]] = deque(maxlen=history_size)
+
+    def _prepare_price_frame(self, px: pd.DataFrame) -> pd.DataFrame:
+        frame = px.copy()
+        if frame.index.tzinfo is None:
+            frame.index = frame.index.tz_localize(timezone.utc)
+        else:
+            frame.index = frame.index.tz_convert(timezone.utc)
+        full_index = pd.date_range(frame.index.min(), frame.index.max(), freq="1min", tz=timezone.utc)
+        frame = frame.reindex(full_index).ffill()
+        frame["ret1m"] = frame["close"].pct_change()
+        frame["logret1m"] = np.log(frame["close"] / frame["close"].shift(1))
+
+        for window in [30, 60, 120, 240]:
+            rv = frame["logret1m"].rolling(window).std()
+            frame[f"realized_vol_{window}m"] = rv
+            frame[f"realized_vol_{window}m_annual"] = _annualize_vol(rv, window)
+
+        frame["rsi_14"] = _rsi(frame["close"], period=14)
+
+        tr = _true_range(frame)
+        for window in [30, 60, 120]:
+            atr = tr.rolling(window).mean()
+            frame[f"atr_{window}m"] = atr
+            frame[f"atr_{window}m_pct"] = atr / (frame["close"].rolling(1).mean() + 1e-12)
+
+        mid = frame["close"].rolling(20).mean()
+        std = frame["close"].rolling(20).std()
+        frame["boll_width_20"] = (2 * std) / (mid + 1e-12)
+
+        for window in [5, 15, 30, 60]:
+            frame[f"momentum_{window}m"] = frame["close"].pct_change(window)
+
+        frame["vol_z_60m"] = (
+            (frame["volume"] - frame["volume"].rolling(60).mean())
+            / (frame["volume"].rolling(60).std() + 1e-12)
+        )
+        frame["volume_rate_30m"] = frame["volume"].rolling(5).sum() / (
+            frame["volume"].rolling(30).sum() + 1e-12
+        )
+        frame["volume_trend_120m"] = frame["volume"].ewm(span=120, adjust=False).mean()
+
+        idx = frame.index
+        hour_float = idx.hour + idx.minute / 60.0
+        frame["intraday_sin"] = np.sin(2 * np.pi * hour_float / 24)
+        frame["intraday_cos"] = np.cos(2 * np.pi * hour_float / 24)
+        frame["dow_sin"] = np.sin(2 * np.pi * idx.dayofweek / 7)
+        frame["dow_cos"] = np.cos(2 * np.pi * idx.dayofweek / 7)
+        frame["is_weekend"] = (idx.dayofweek >= 5).astype(float)
+
+        return frame
+
+    def _extract_market_features(self, frame: pd.DataFrame) -> Dict[str, float]:
+        last = frame.iloc[-1]
+        features: Dict[str, float] = {}
+        for col in frame.columns:
+            if col in {"open", "high", "low", "close", "volume", "ret1m", "logret1m"}:
+                continue
+            value = last[col]
+            features[f"feat_{col}"] = float(value) if pd.notna(value) else np.nan
+        return features
+
+    def _compute_context_features(self, event_time: datetime, sentiment: float) -> Dict[str, float]:
+        event_time_utc = _as_utc(event_time)
+        horizon_60 = event_time_utc - timedelta(minutes=60)
+        horizon_180 = event_time_utc - timedelta(minutes=180)
+
+        # purge old events (> 4h)
+        cutoff = event_time_utc - timedelta(hours=4)
+        filtered: Deque[tuple[datetime, float]] = deque(maxlen=self.history.maxlen)
+        for ts, sent in self.history:
+            if ts >= cutoff:
+                filtered.append((ts, sent))
+        self.history = filtered
+
+        last_ten = list(self.history)[-10:]
+        sent_values = [s for _, s in last_ten]
+        sent_mean = float(np.mean(sent_values)) if sent_values else 0.0
+        sent_std = float(np.std(sent_values, ddof=1)) if len(sent_values) > 1 else 0.0
+
+        count_60 = sum(1 for ts, _ in self.history if ts >= horizon_60)
+        count_180 = sum(1 for ts, _ in self.history if ts >= horizon_180)
+
+        return {
+            "feat_sent_roll_mean_10": sent_mean,
+            "feat_sent_roll_std_10": sent_std,
+            "feat_news_count_60m": float(count_60),
+            "feat_news_count_180m": float(count_180),
+        }
+
+    def build(self, event_time: datetime, sentiment: Optional[float] = None) -> Dict[str, float]:
+        px = self.source.get_price_window(event_time)
+        frame = self._prepare_price_frame(px)
+        market = self._extract_market_features(frame)
+        context = self._compute_context_features(event_time, float(sentiment or 0.0))
+
+        features = {**market, **context}
+        if self.feat_stats:
+            for key, stats in self.feat_stats.items():
+                if key not in features:
+                    features[key] = stats.get("mean", 0.0)
+        self.history.append((_as_utc(event_time), float(sentiment or 0.0)))
+        return features

--- a/live/model_paths.py
+++ b/live/model_paths.py
@@ -1,0 +1,63 @@
+"""Utilities for locating model export directories used by the live stack."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Sequence
+
+
+def _as_path(candidate: str | Path, base_dir: Path) -> Path:
+    path = Path(candidate).expanduser()
+    if not path.is_absolute():
+        path = (base_dir / path).resolve()
+    return path
+
+
+def resolve_model_dir(
+    base_dir: Path,
+    env_var: str = "MODEL_DIR",
+    candidates: Sequence[str | Path] | None = None,
+) -> Path:
+    """Return the first existing model directory from the provided candidates.
+
+    Parameters
+    ----------
+    base_dir:
+        Directory relative to which relative candidates will be resolved.
+    env_var:
+        Environment variable name that can override the search path.
+    candidates:
+        Ordered collection of directory names (relative or absolute) to try.
+    """
+
+    if candidates is None:
+        candidates = ("models/bert_v7_1_plus", "models/bert_v7_1_multi")
+
+    tried: list[Path] = []
+    env_value = os.environ.get(env_var)
+    if env_value:
+        env_path = _as_path(env_value, base_dir)
+        tried.append(env_path)
+        if env_path.exists():
+            return env_path
+        print(
+            f"[WARN] {env_var}={env_value!r} introuvable, tentative avec les répertoires par défaut..."
+        )
+    else:
+        env_path = None
+
+    for candidate in candidates:
+        cand_path = _as_path(candidate, base_dir)
+        tried.append(cand_path)
+        if cand_path.exists():
+            if env_path and cand_path != env_path:
+                print(
+                    f"[WARN] Utilisation du modèle de secours {cand_path} après échec sur {env_path}"
+                )
+            return cand_path
+
+    tried_str = ", ".join(str(path) for path in tried)
+    raise FileNotFoundError(
+        f"Aucun répertoire modèle trouvé. Emplacements testés : {tried_str}"
+    )

--- a/live/state_utils.py
+++ b/live/state_utils.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def default_state() -> Dict[str, Any]:
+    """Return a fresh default bot state."""
+    return {
+        "starting_equity": 10000.0,
+        "equity": 10000.0,
+        "position": None,
+        "trades": [],
+        "equity_curve": [],
+        "last_pred_id": None,
+        "last_signal": None,
+    }
+
+
+def _clone_default(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _clone_default(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_clone_default(v) for v in value]
+    return value
+
+
+def ensure_state_defaults(state: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Ensure the provided state dictionary has all required keys."""
+    if not isinstance(state, dict):
+        state = default_state()
+    defaults = default_state()
+    for key, value in defaults.items():
+        if key not in state or state[key] is None:
+            state[key] = _clone_default(value)
+    # Equity should not fall below starting equity if missing or invalid
+    try:
+        equity = float(state.get("equity", defaults["equity"]))
+    except (TypeError, ValueError):
+        equity = defaults["equity"]
+    try:
+        starting_equity = float(state.get("starting_equity", defaults["starting_equity"]))
+    except (TypeError, ValueError):
+        starting_equity = defaults["starting_equity"]
+    state["starting_equity"] = starting_equity
+    if equity <= 0:
+        equity = starting_equity
+    state["equity"] = equity
+    return state
+
+
+def load_state_file(path: Path, *, strict: bool = False) -> Dict[str, Any]:
+    """Load a bot state JSON file and normalise missing keys.
+
+    When ``strict`` is True, parsing errors are re-raised so the caller can
+    surface them to the user. By default the function falls back to the
+    default state when a decoding issue occurs.
+    """
+    if not path.exists():
+        return default_state()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        if strict:
+            raise
+        return default_state()
+    return ensure_state_defaults(raw)
+
+
+def save_state_file(path: Path, state: Dict[str, Any]) -> None:
+    """Persist the bot state to disk with UTF-8 encoding."""
+    safe_state = ensure_state_defaults(state)
+    tmp_path = path.with_suffix(".tmp")
+    tmp_path.write_text(json.dumps(safe_state, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def build_last_signal(
+    *,
+    news_id: str,
+    prediction: str,
+    confidence: Optional[float],
+    ret_pred: Optional[float],
+    mag_pred: Optional[float],
+    atr_pct: Optional[float],
+    article_status: str = "",
+    article_found: Optional[bool] = None,
+    article_chars: Optional[int] = None,
+    text_chars: Optional[int] = None,
+    text_source: str = "",
+    title: str = "",
+    url: str = "",
+    features_status: str = "",
+    plan: Optional[Dict[str, Any]] = None,
+    timestamp: Optional[str] = None,
+    extra_fields: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a normalised payload for the latest model signal."""
+    if timestamp is None:
+        timestamp = datetime.now(timezone.utc).astimezone().isoformat()
+
+    payload: Dict[str, Any] = {
+        "time": timestamp,
+        "news_id": news_id,
+        "prediction": prediction,
+        "confidence": None if confidence is None else float(confidence),
+        "ret_pred": None if ret_pred is None else float(ret_pred),
+        "mag_pred": None if mag_pred is None else float(mag_pred),
+        "atr_pct": None if atr_pct is None else float(atr_pct),
+        "article_status": article_status,
+        "article_found": bool(article_found) if article_found is not None else None,
+        "article_chars": None if article_chars is None else int(article_chars),
+        "text_chars": None if text_chars is None else int(text_chars),
+        "text_source": text_source,
+        "title": title[:200] if title else "",
+        "url": url,
+        "features_status": features_status,
+    }
+
+    if plan:
+        for key in ("leverage", "planned_leverage"):
+            if key in plan and plan[key] is not None:
+                payload["planned_leverage"] = int(plan[key])
+                break
+        if plan.get("risk_fraction") is not None:
+            payload["risk_fraction"] = float(plan["risk_fraction"])
+        if plan.get("risk_budget") is not None:
+            payload["risk_budget"] = float(plan["risk_budget"])
+        if plan.get("size_usd") is not None:
+            payload["size_usd"] = float(plan["size_usd"])
+
+    if extra_fields:
+        for key, value in extra_fields.items():
+            payload[key] = value
+
+    return payload
+
+
+def update_last_signal_file(path: Path, signal: Dict[str, Any]) -> Dict[str, Any]:
+    """Update the last signal field in the bot state file and return the state."""
+    state = load_state_file(path)
+    state["last_signal"] = signal
+    save_state_file(path, state)
+    return state

--- a/live_trader.py
+++ b/live_trader.py
@@ -17,13 +17,20 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Optional
 
+from live.model_paths import resolve_model_dir
+
 import pandas as pd
 import requests
 
 PRED_FILE = Path("live_predictions.csv")
 PRICE_FILE = Path("price_pipe.csv")
 STATE_FILE = Path("bot_state.json")
-MODEL_DIR = Path("./models/bert_v7_1_multi")
+SCRIPT_ROOT = Path(__file__).resolve().parent
+MODEL_DIR = resolve_model_dir(
+    base_dir=SCRIPT_ROOT,
+    env_var="MODEL_DIR",
+    candidates=("models/bert_v7_1_plus", "models/bert_v7_1_multi", "models/bert_v7_multi"),
+)
 REFRESH_SEC = 2
 
 CONF_OPEN = 0.62
@@ -186,7 +193,16 @@ def init_state() -> Dict:
     if STATE_FILE.exists():
         try:
             with STATE_FILE.open("r", encoding="utf-8") as fh:
-                return json.load(fh)
+                data = json.load(fh)
+                if isinstance(data, dict):
+                    data.setdefault("starting_equity", 10000.0)
+                    data.setdefault("equity", data.get("starting_equity", 10000.0))
+                    data.setdefault("position", None)
+                    data.setdefault("trades", [])
+                    data.setdefault("equity_curve", [[now_iso(), data.get("equity", 10000.0)]])
+                    data.setdefault("last_pred_id", None)
+                    data.setdefault("last_signal", None)
+                    return data
         except Exception as exc:
             print(f"[WARN] unable to read {STATE_FILE}: {exc}")
     return {
@@ -196,6 +212,7 @@ def init_state() -> Dict:
         "trades": [],
         "equity_curve": [[now_iso(), 10000.0]],
         "last_pred_id": None,
+        "last_signal": None,
     }
 
 
@@ -251,6 +268,13 @@ def latest_predictions(n: int = 40) -> pd.DataFrame:
         "feat_realized_vol_60m_annual",
         "feat_vol_z_60m",
         "feat_volume_rate_30m",
+        "article_status",
+        "article_found",
+        "article_chars",
+        "text_source",
+        "text_chars",
+        "titles_joined",
+        "body_concat",
     }
     for col in required:
         if col not in df.columns:
@@ -278,6 +302,9 @@ def close_position(state: Dict, price: float, reason: str = "CLOSE") -> None:
             "title": pos.get("title", ""),
             "leverage": pos.get("leverage", 1),
             "risk_fraction": round(float(pos.get("risk_fraction", 0.0)), 4),
+            "confidence": round(float(pos.get("confidence", 0.0)), 4),
+            "ret_pred": round(float(pos.get("ret_pred", 0.0)), 6),
+            "article_status": pos.get("article_status"),
         }
     )
     state["position"] = None
@@ -304,6 +331,11 @@ def open_position(state: Dict, side: str, price: float, title: str, plan: Dict) 
         "risk_budget": plan.get("risk_budget", 0.0),
         "atr_pct": plan.get("atr_pct"),
         "confidence": plan.get("confidence", 0.0),
+        "article_status": plan.get("article_status"),
+        "article_found": plan.get("article_found"),
+        "text_source": plan.get("text_source"),
+        "article_chars": plan.get("article_chars"),
+        "text_chars": plan.get("text_chars"),
     }
     state["trades"].append(
         {
@@ -315,6 +347,9 @@ def open_position(state: Dict, side: str, price: float, title: str, plan: Dict) 
             "title": title[:160],
             "leverage": leverage,
             "risk_fraction": round(plan.get("risk_fraction", 0.0), 4),
+            "confidence": round(plan.get("confidence", 0.0), 4),
+            "ret_pred": round(plan.get("ret_pred", 0.0), 6),
+            "article_status": plan.get("article_status"),
         }
     )
 
@@ -373,10 +408,51 @@ def main():
                 mag_value = abs(ret_pred)
                 atr_pct = safe_float(last_row.get("feat_atr_60m_pct"))
                 title = str(last_row.get("title", ""))
+                article_status = str(last_row.get("article_status", ""))
+                article_found = bool(last_row.get("article_found", False))
+                article_chars = int(float(last_row.get("article_chars", 0) or 0))
+                text_source = str(last_row.get("text_source", ""))
+                url = str(last_row.get("url", ""))
+
+                text_chars = int(float(last_row.get("text_chars", 0) or 0))
+
+                plan = build_risk_plan(state, confidence, ret_pred, thresholds, atr_pct)
+                if plan:
+                    plan.setdefault("article_status", article_status)
+                    plan.setdefault("article_found", article_found)
+                    plan.setdefault("text_source", text_source)
+                    plan.setdefault("article_chars", article_chars)
+                    plan.setdefault("text_chars", text_chars)
+
+                signal_info = {
+                    "time": now_iso(),
+                    "news_id": news_id,
+                    "prediction": pred,
+                    "confidence": float(confidence),
+                    "ret_pred": float(ret_pred),
+                    "mag_pred": float(mag_value),
+                    "atr_pct": None if atr_pct is None else float(atr_pct),
+                    "article_status": article_status,
+                    "article_found": article_found,
+                    "article_chars": article_chars,
+                    "text_chars": text_chars,
+                    "text_source": text_source,
+                    "title": title[:200],
+                    "url": url,
+                    "features_status": str(last_row.get("features_status", "")),
+                }
+                if plan:
+                    signal_info.update(
+                        {
+                            "planned_leverage": plan.get("leverage"),
+                            "risk_fraction": plan.get("risk_fraction"),
+                            "risk_budget": plan.get("risk_budget"),
+                        }
+                    )
+                state["last_signal"] = signal_info
 
                 now_s = time.time()
                 if now_s - last_action_ts >= MIN_COOLDOWN_SEC:
-                    plan = build_risk_plan(state, confidence, ret_pred, thresholds, atr_pct)
                     if state.get("position") is None:
                         if pred == "bullish" and confidence >= CONF_OPEN and price and plan:
                             open_position(state, "long", price, title, plan)

--- a/train_model_v7_1_multi.py
+++ b/train_model_v7_1_multi.py
@@ -18,7 +18,7 @@ Prérequis dataset :
   * feat_* (features marché à t0)
 
 Sorties :
-- models/bert_v7_1_multi/
+- models/bert_v7_1_plus/ (par défaut — overridable via $OUTPUT_DIR)
   * poids + tokenizer
   * best.json
   * training_log.txt, metrics_log.jsonl
@@ -56,7 +56,7 @@ LR = 3e-5
 WEIGHT_DECAY = 0.01
 WARMUP_FRAC = 0.05
 
-OUTPUT_DIR = "models/bert_v7_1_multi"
+OUTPUT_DIR = os.environ.get("OUTPUT_DIR", "models/bert_v7_1_plus")
 SEED = 42
 USE_AMP = True
 EARLY_STOP_PATIENCE = 2


### PR DESCRIPTION
## Summary
- add a shared resolver that locates the first available model export and warns when falling back
- use the resolver across bridge inference, the paper trader, and the Streamlit dashboard while re-exporting it from the live package
- document the automatic fallback behaviour for model directories in the README

## Testing
- python -m py_compile bridge_inference.py live_trader.py app.py live/model_paths.py

------
https://chatgpt.com/codex/tasks/task_e_68d08d0a8e6c8328a4c948be49f68e07